### PR TITLE
don't exceed array bounds when creating random_index

### DIFF
--- a/qotd.rb
+++ b/qotd.rb
@@ -31,7 +31,7 @@ server = TCPServer.new 17
 
 loop do
 	Thread.start(server.accept) do |client|
-		random_index = rand(quotes_array.length + 1)
+		random_index = rand(quotes_array.length)
 		@quote_body = quotes_array[random_index]["Quote"]
 		@quote_author = quotes_array[random_index]["Author"]
 


### PR DESCRIPTION
Hello-

I saw your blog post linked from Hacker News, and I think that this addresses a bug that someone reported there:

> The QOTD seems to just hang sometimes. Anyone have any guesses as to why?

https://news.ycombinator.com/item?id=9895547

``` ruby
random_index = rand(quotes_array.length + 1)
```

can potentially return a value of `quotes_array.length`. However, since Ruby arrays are zero based, such an index would exceed the bounds of `quotes_array`, _e.g._:

``` ruby
>> a = [:a, :b]
=> [:a, :b]
>> a.length
=> 2
>> a[0]
=> :a
>> a[1]
=> :b
>> a[2]
=> nil
```
